### PR TITLE
iOS 9

### DIFF
--- a/LSStatusBarClient.mm
+++ b/LSStatusBarClient.mm
@@ -203,7 +203,7 @@ mach_port_t LSBServerPort()
 	}
 	*/
 	
-	int keyidx = (cfvers >= CF_70) ? 32 : 24;
+	int keyidx = (cfvers >= CF_70) ? ((cfvers >= CF_90) ? 64 : 32) : 24;
 	
 	//NSDesc(_currentMessage);
 	

--- a/common.h
+++ b/common.h
@@ -77,7 +77,8 @@ enum CFVers
 	CF_70 = 1024,
 	CF_71 = 2048,
 	CF_80 = 4096,
-	CF_81 = 8192
+	CF_81 = 8192,
+	CF_90 = 16384
 };
 
 extern CFVers cfvers;

--- a/libstatusbar.mm
+++ b/libstatusbar.mm
@@ -699,6 +699,10 @@ CFVers QuantizeCFVers()
 	{
 		return CF_81;
 	}
+	else if(kCFCoreFoundationVersionNumber == 1240.10)
+	{
+		return CF_90;
+	}
 	
 //	else if(kCFCoreFoundationVersionNumber == 847.23)
 //	{


### PR DESCRIPTION
There are still some strange things going on (the icons sometimes disappear when I unlock my device, they don't show up in certain App store Apps (Waze) but work fine in other App store Apps (Alien Blue), but this is at least partially working.

And according to this, https://twitter.com/saurik/status/654198997024796672 and http://iphonedevwiki.net/index.php/Updating_extensions_for_iOS_9#Compilation_changes, you should compile with:

libstatusbar_LDFLAGS += -Wl,-segalign,4000 -lsubstrate -lrocketbootstrap
